### PR TITLE
Logs always written, but only kept if necessary

### DIFF
--- a/deeplodocus/core/project/deep_structure/config/project.yaml
+++ b/deeplodocus/core/project/deep_structure/config/project.yaml
@@ -3,6 +3,6 @@ name: "DeepProject"
 cv_library: 1
 
 logs:
-  write: True
+  keep: False
 
 on_wake: # frontal_lobe.load()

--- a/deeplodocus/utils/logs.py
+++ b/deeplodocus/utils/logs.py
@@ -57,9 +57,8 @@ class Logs(object):
         """
         try:
             os.remove(self.__get_path())
-            print("%s removed" % self.__get_path())
-        except FileNotFoundError as e:
-            print(e)
+        except FileNotFoundError:
+            pass
 
     def add(self, text: str, write_time=True) -> None:
         """

--- a/deeplodocus/utils/namespace.py
+++ b/deeplodocus/utils/namespace.py
@@ -79,12 +79,8 @@ class Namespace(object):
         :return:
         """
         summary = self.__get_summary(tab_size=tab_size).split("\n")
-        try:
-            write_logs = self.project.logs.write
-        except AttributeError:
-            write_logs = False
         for line in summary:
-            Notification(DEEP_NOTIF_INFO, line, write=write_logs)
+            Notification(DEEP_NOTIF_INFO, line)
 
     def check(self, item, sub_space=None):
         """

--- a/deeplodocus/utils/notification.py
+++ b/deeplodocus/utils/notification.py
@@ -60,7 +60,7 @@ class Notification(object):
     Display a custom message to the user
     """
 
-    def __init__(self, notif_type: int, message: str, write: bool=False) -> None:
+    def __init__(self, notif_type: int, message: str, write: bool=True) -> None:
         """
         AUTHORS:
         --------


### PR DESCRIPTION
Notification objects write by default now, allow them to do so.
On brain.sleep():
    if logs are to be kept, logs are closed
    if logs are not to be kept, logs are deleted
