### PR TITLE
Make brain.model always a nn.DataParallel object

### DIFF
--- a/deeplodocus/brain/frontal_lobe.py
+++ b/deeplodocus/brain/frontal_lobe.py
@@ -259,7 +259,7 @@ class FrontalLobe(object):
             self.model = model
             Notification(
                 DEEP_NOTIF_SUCCESS,
-                DEEP_MSG_MODEL_LOADED % (self.config.model.name, self.model.module.module)
+                DEEP_MSG_MODEL_LOADED % (self.model.name, self.model.origin)
             )
 
     def load_optimizer(self):

--- a/deeplodocus/core/inference/tester.py
+++ b/deeplodocus/core/inference/tester.py
@@ -107,9 +107,9 @@ class Tester(GenericEvaluator):
             inputs, labels, additional_data = self.clean_single_element_list(minibatch)
 
             # Set the data to the corresponding device
-            inputs = self.to_device(inputs, self.model.module.device)
-            labels = self.to_device(labels, self.model.module.device)
-            additional_data = self.to_device(labels, self.model.module.device)
+            inputs = self.to_device(inputs, self.model.device)
+            labels = self.to_device(labels, self.model.device)
+            additional_data = self.to_device(labels, self.model.device)
 
             # Infer the outputs from the model over the given mini batch
             outputs = model(*inputs)

--- a/deeplodocus/core/inference/trainer.py
+++ b/deeplodocus/core/inference/trainer.py
@@ -206,9 +206,9 @@ class Trainer(GenericEvaluator):
                 self.optimizer.zero_grad()
 
                 # Set the data to the corresponding device
-                inputs = self.to_device(inputs, self.model.module.device)
-                labels = self.to_device(labels, self.model.module.device)
-                additional_data = self.to_device(additional_data, self.model.module.device)
+                inputs = self.to_device(inputs, self.model.device)
+                labels = self.to_device(labels, self.model.device)
+                additional_data = self.to_device(additional_data, self.model.device)
 
                 # Infer the output of the batch
                 outputs = self.model(*inputs)

--- a/deeplodocus/core/model/model.py
+++ b/deeplodocus/core/model/model.py
@@ -11,188 +11,176 @@ from deeplodocus.utils.flags.notif import *
 
 def load_model(name, module, kwargs, device, device_ids=None, input_size=None, batch_size=None):
     # Get the model, should be nn.Module
-    model, module = get_module(name=name, module=module, browse=DEEP_MODULE_MODELS)
-    if model is None:
+    module, origin = get_module(name=name, module=module, browse=DEEP_MODULE_MODELS)
+    if module is None:
         return None
-
-    # Define our model that inherits from the nn.Module
-    class Model(model):
-
-        def __init__(self, name, module, input_size, batch_size, device_ids, device, kwargs_dict, **kwargs):
-            super(Model, self).__init__(**kwargs)
-            self.name = name
-            self.module = module
-            self.input_size = input_size
-            self.batch_size = batch_size
-            self.kwargs_dict = kwargs_dict
-            self.device_ids = device_ids
-            self.device = device
-
-        def summary(self):
-            """
-            AUTHORS:
-            --------
-
-            :author: Alix Leroy
-            :author: Samuel Westlake
-
-            DESCRIPTION:
-            ------------
-
-            Summarise the model
-
-            PARAMETERS:
-            -----------
-
-            None
-
-            RETURN:
-            -------
-
-            :return: None
-            """
-
-            if self.input_size is not None:
-                self.__summary()
-            else:
-                Notification(DEEP_NOTIF_ERROR, "Model's input size not given, the summary cannot be displayed.")
-
-        def __summary(self):
-            """
-            AUTHORS:
-            --------
-
-            :author:  https://github.com/sksq96/pytorch-summary
-            :author: Alix Leroy
-
-            DESCRIPTION:
-            ------------
-
-            Print a summary of the current model
-
-            PARAMETERS:
-            -----------
-
-            None
-
-            RETURN:
-            -------
-
-            :return: None
-            """
-
-            def register_hook(module):
-
-                def hook(module, input, output):
-                    class_name = str(module.__class__).split(".")[-1].split("'")[0]
-                    module_idx = len(summary)
-                    m_key = "%s-%i" % (class_name, module_idx + 1)
-                    summary[m_key] = OrderedDict()
-                    summary[m_key]["input_shape"] = list(input[0].size())
-                    summary[m_key]["input_shape"][0] = self.batch_size
-                    if isinstance(output, (list, tuple)):
-                        summary[m_key]["output_shape"] = [[-1] + list(o.size())[1:] for o in output]
-                    else:
-                        summary[m_key]["output_shape"] = list(output.size())
-                        summary[m_key]["output_shape"][0] = self.batch_size
-                    params = 0
-                    if hasattr(module, "weight") and hasattr(module.weight, "size"):
-                        params += torch.prod(torch.LongTensor(list(module.weight.size())))
-                        summary[m_key]["trainable"] = module.weight.requires_grad
-                    if hasattr(module, "bias") and hasattr(module.bias, "size"):
-                        params += torch.prod(torch.LongTensor(list(module.bias.size())))
-                    summary[m_key]["nb_params"] = params
-
-                if (
-                        not isinstance(module, nn.Sequential)
-                        and not isinstance(module, nn.ModuleList)
-                        and not (module == model)
-                ):
-                    hooks.append(module.register_forward_hook(hook))
-
-            # Batch_size of 2 for batchnorm
-            x = [torch.rand(2, *in_size) for in_size in input_size]
-
-            # Move the batch to the same device as the model
-            x = [i.to(self.device) for i in x]
-
-            # Create properties
-            summary = OrderedDict()
-            hooks = []
-
-            # Register hook
-            self.apply(register_hook)
-
-            # Make a forward pass
-            self.forward(*x)
-
-            # Remove these hooks
-            for h in hooks:
-                h.remove()
-
-            Notification(DEEP_NOTIF_INFO, '================================================================')
-            Notification(DEEP_NOTIF_INFO, "MODEL : %s from %s" % (self.name, self.module))
-            Notification(DEEP_NOTIF_INFO, '================================================================')
-            line_new = '{:>20}  {:>25} {:>15}'.format('Layer (type)', 'Output Shape', 'Param #')
-            Notification(DEEP_NOTIF_INFO, line_new)
-            Notification(DEEP_NOTIF_INFO, '----------------------------------------------------------------')
-            total_params = 0
-            total_output = 0
-            trainable_params = 0
-            for layer in summary:
-                # Input_shape, output_shape, trainable, nb_params
-                line_new = '{:>20}  {:>25} {:>15}'.format(layer, str(summary[layer]['output_shape']),
-                                                          '{0:,}'.format(summary[layer]['nb_params']))
-                total_params += summary[layer]['nb_params']
-                total_output += np.prod(summary[layer]["output_shape"])
-                if 'trainable' in summary[layer]:
-                    if summary[layer]['trainable'] == True:
-                        trainable_params += summary[layer]['nb_params']
-                Notification(DEEP_NOTIF_INFO, line_new)
-
-            # Assume 4 bytes/number (float on cuda).
-            total_input_size = abs(np.prod(input_size) * self.batch_size * 4. / (1024 ** 2.))
-            total_output_size = abs(2. * total_output * 4. / (1024 ** 2.))  # x2 for gradients
-            total_params_size = abs(total_params.numpy() * 4. / (1024 ** 2.))
-            total_size = total_params_size + total_output_size + total_input_size
-            Notification(DEEP_NOTIF_INFO, '----------------------------------------------------------------')
-            Notification(DEEP_NOTIF_INFO, "Input size : %s" % self.input_size)
-            Notification(DEEP_NOTIF_INFO, "Batch size : %s" % self.batch_size)
-            for key, item in self.kwargs_dict.items():
-                Notification(DEEP_NOTIF_INFO, "%s : %s" % (key, item))
-            Notification(DEEP_NOTIF_INFO, '----------------------------------------------------------------')
-            Notification(DEEP_NOTIF_INFO, 'Total params: {0:,}'.format(total_params))
-            Notification(DEEP_NOTIF_INFO, 'Trainable params: {0:,}'.format(trainable_params))
-            Notification(DEEP_NOTIF_INFO, 'Non-trainable params: {0:,}'.format(total_params - trainable_params))
-            Notification(DEEP_NOTIF_INFO, '----------------------------------------------------------------')
-            Notification(DEEP_NOTIF_INFO, "Input size (MB): %0.2f" % total_input_size)
-            Notification(DEEP_NOTIF_INFO, "Forward/backward pass size (MB): %0.2f" % total_output_size)
-            Notification(DEEP_NOTIF_INFO, "Params size (MB): %0.2f" % total_params_size)
-            Notification(DEEP_NOTIF_INFO, "Estimated Total Size (MB): %0.2f" % total_size)
-            Notification(DEEP_NOTIF_INFO, "")
-
-    # model = nn.DataParallel(module=model)
 
     # Initialise the model
     model = Model(
-        name=name,
-        module=module,
-        input_size=input_size,
-        batch_size=batch_size,
+        module=module(**kwargs.get()),
         device_ids=device_ids,
         device=device,
-        kwargs_dict=kwargs.get(),
-        **kwargs.get()
+        name=name,
+        origin=origin,
+        input_size=input_size,
+        model_kwargs=kwargs.get()
     )
-
-    # Get number of devices
-    # n_devices = torch.cuda.device_count() if device_ids is None else len(device_ids)
-
-    # If there are multiple GPUs, use DataParallel
-    # if n_devices > 1:
-    model = nn.DataParallel(module=model, device_ids=device_ids)
 
     # Send to the appropriate device
     model.to(device)
 
     return model
+
+
+# Define our model that inherits from the nn.Module
+class Model(nn.DataParallel):
+
+    def __init__(self, module, device_ids, device,
+                 name="DataParallel",
+                 origin="Unknown",
+                 input_size=None,
+                 batch_size=None,
+                 model_kwargs=None):
+        super(Model, self).__init__(module, device_ids)
+        self.device = device
+        self.name = name
+        self.origin = origin
+        self.input_size = input_size
+        self.batch_size = batch_size
+        self.model_kwargs = {} if model_kwargs is None else model_kwargs
+
+    def summary(self):
+        """
+        AUTHORS:
+        --------
+        :author: Alix Leroy
+        :author: Samuel Westlake
+        DESCRIPTION:
+        ------------
+        Summarise the model
+        PARAMETERS:
+        -----------
+        None
+        RETURN:
+        -------
+        :return: None
+        """
+
+        if self.input_size is not None:
+            self.__summary()
+        else:
+            Notification(DEEP_NOTIF_ERROR, "Model's input size not given, the summary cannot be displayed.")
+
+    def __summary(self):
+        """
+        AUTHORS:
+        --------
+
+        :author:  https://github.com/sksq96/pytorch-summary
+        :author: Alix Leroy
+
+        DESCRIPTION:
+        ------------
+
+        Print a summary of the current model
+
+        PARAMETERS:
+        -----------
+
+        None
+
+        RETURN:
+        -------
+
+        :return: None
+        """
+
+        def register_hook(module):
+
+            def hook(module, input, output):
+                class_name = str(module.__class__).split(".")[-1].split("'")[0]
+                module_idx = len(summary)
+                m_key = "%s-%i" % (class_name, module_idx + 1)
+                summary[m_key] = OrderedDict()
+                summary[m_key]["input_shape"] = list(input[0].size())
+                summary[m_key]["input_shape"][0] = self.batch_size
+                if isinstance(output, (list, tuple)):
+                    summary[m_key]["output_shape"] = [[-1] + list(o.size())[1:] for o in output]
+                else:
+                    summary[m_key]["output_shape"] = list(output.size())
+                    summary[m_key]["output_shape"][0] = self.batch_size
+                params = 0
+                if hasattr(module, "weight") and hasattr(module.weight, "size"):
+                    params += torch.prod(torch.LongTensor(list(module.weight.size())))
+                    summary[m_key]["trainable"] = module.weight.requires_grad
+                if hasattr(module, "bias") and hasattr(module.bias, "size"):
+                    params += torch.prod(torch.LongTensor(list(module.bias.size())))
+                summary[m_key]["nb_params"] = params
+
+            if (
+                    not isinstance(module, nn.Sequential)
+                    and not isinstance(module, nn.ModuleList)
+                    and not (module == model)
+            ):
+                hooks.append(module.register_forward_hook(hook))
+
+        # Batch_size of 2 for batchnorm
+        x = [torch.rand(2, *in_size) for in_size in input_size]
+
+        # Move the batch to the same device as the model
+        x = [i.to(self.device) for i in x]
+
+        # Create properties
+        summary = OrderedDict()
+        hooks = []
+
+        # Register hook
+        self.apply(register_hook)
+
+        # Make a forward pass
+        self.forward(*x)
+
+        # Remove these hooks
+        for h in hooks:
+            h.remove()
+
+        Notification(DEEP_NOTIF_INFO, '================================================================')
+        Notification(DEEP_NOTIF_INFO, "MODEL : %s from %s" % (self.name, self.module))
+        Notification(DEEP_NOTIF_INFO, '================================================================')
+        line_new = '{:>20}  {:>25} {:>15}'.format('Layer (type)', 'Output Shape', 'Param #')
+        Notification(DEEP_NOTIF_INFO, line_new)
+        Notification(DEEP_NOTIF_INFO, '----------------------------------------------------------------')
+        total_params = 0
+        total_output = 0
+        trainable_params = 0
+        for layer in summary:
+            # Input_shape, output_shape, trainable, nb_params
+            line_new = '{:>20}  {:>25} {:>15}'.format(layer, str(summary[layer]['output_shape']),
+                                                      '{0:,}'.format(summary[layer]['nb_params']))
+            total_params += summary[layer]['nb_params']
+            total_output += np.prod(summary[layer]["output_shape"])
+            if 'trainable' in summary[layer]:
+                if summary[layer]['trainable'] == True:
+                    trainable_params += summary[layer]['nb_params']
+            Notification(DEEP_NOTIF_INFO, line_new)
+
+        # Assume 4 bytes/number (float on cuda).
+        total_input_size = abs(np.prod(input_size) * self.batch_size * 4. / (1024 ** 2.))
+        total_output_size = abs(2. * total_output * 4. / (1024 ** 2.))  # x2 for gradients
+        total_params_size = abs(total_params.numpy() * 4. / (1024 ** 2.))
+        total_size = total_params_size + total_output_size + total_input_size
+        Notification(DEEP_NOTIF_INFO, '----------------------------------------------------------------')
+        Notification(DEEP_NOTIF_INFO, "Input size : %s" % self.input_size)
+        Notification(DEEP_NOTIF_INFO, "Batch size : %s" % self.batch_size)
+        for key, item in self.model_kwargs.items():
+            Notification(DEEP_NOTIF_INFO, "%s : %s" % (key, item))
+        Notification(DEEP_NOTIF_INFO, '----------------------------------------------------------------')
+        Notification(DEEP_NOTIF_INFO, 'Total params: {0:,}'.format(total_params))
+        Notification(DEEP_NOTIF_INFO, 'Trainable params: {0:,}'.format(trainable_params))
+        Notification(DEEP_NOTIF_INFO, 'Non-trainable params: {0:,}'.format(total_params - trainable_params))
+        Notification(DEEP_NOTIF_INFO, '----------------------------------------------------------------')
+        Notification(DEEP_NOTIF_INFO, "Input size (MB): %0.2f" % total_input_size)
+        Notification(DEEP_NOTIF_INFO, "Forward/backward pass size (MB): %0.2f" % total_output_size)
+        Notification(DEEP_NOTIF_INFO, "Params size (MB): %0.2f" % total_params_size)
+        Notification(DEEP_NOTIF_INFO, "Estimated Total Size (MB): %0.2f" % total_size)
+        Notification(DEEP_NOTIF_INFO, "")


### PR DESCRIPTION
I was having problems making the model work as both a nn.Module and an nn.DataParallel, so it is always a nn.DataParallel for now.
You can call model.device again.
model.summary() is currently broken, but can be fixed.
Multi-GPU tested on HPC. 